### PR TITLE
Grab paramaters before recursing on next token

### DIFF
--- a/parameter_sync.py
+++ b/parameter_sync.py
@@ -76,14 +76,18 @@ def process_parameters_with_prefix(param_prefix, cred_path, aws_region, aws_acce
             query_result = ssm.describe_parameters(Filters=[{'Key': 'Name', 'Values': [prefix]}], NextToken=next_token)
         else:
             query_result = ssm.describe_parameters(Filters=[{'Key': 'Name', 'Values': [prefix]}])
-
+        logging.debug("Query result %s" % str(query_result))
         if 'ResponseMetadata' in query_result:
             if 'HTTPStatusCode' in query_result['ResponseMetadata']:
                 if query_result['ResponseMetadata']['HTTPStatusCode'] == 200:
-                    if 'NextToken' in query_result:
-                        parameter_list.extend(get_parameters_with_prefix(prefix, next_token=query_result['NextToken']))
-                    else:
+                    if next_token is None:
+                        #grab the parameter list on the first run or you'll lose it
                         parameter_list.extend(query_result['Parameters'])
+                    if 'NextToken' in query_result:
+                        logging.debug("Next token found")
+                        parameter_list.extend(get_parameters_with_prefix(prefix, next_token=query_result['NextToken']))
+                        logging.debug("Out of recursion")
+        logging.debug("Parameter List %s" % parameter_list)
         return parameter_list
 
 


### PR DESCRIPTION
In some new development SSM was only sending 9 parameters and the next token but for some reason we never captured the first 9 parameters before it moved on to capture the next.  Adjusted the logic so that we should capture the parameters from the first call before it moves on to the next token position.